### PR TITLE
26 make socketio host address dynamic in frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## next
 
 * Add pinia for state management
+* Change behavior of SocketIO host detection
 * fix reverse proxy example
 * remove web-font loader as dependency
 * Fix `docker-compose.yml` depends_on bug

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -4,6 +4,8 @@ services:
   backend:
     build:
       context: js
+      args:
+        - VUE_APP_SOCKET_ENDPOINT
     entrypoint: [ "npm", "run", "server"]
     environment:
       - BACKEND_AUTH_TOKEN=${BACKEND_AUTH_TOKEN:-change_me}

--- a/js/Dockerfile
+++ b/js/Dockerfile
@@ -9,6 +9,8 @@ RUN npm install
 
 COPY . .
 
+ARG VUE_APP_SOCKET_ENDPOINT
+
 RUN [ "npm", "run",  "build"]
 
 ENTRYPOINT [ "npm", "run", "server" ]

--- a/js/src/services/socketio.service.ts
+++ b/js/src/services/socketio.service.ts
@@ -3,7 +3,10 @@ import { io } from "socket.io-client";
 import type { ClientToServerEvents, ServerToClientEvents } from "../communication";
 
 export const useSocketIO = () => {
-  const socket: Socket<ServerToClientEvents, ClientToServerEvents> = io(process.env.VUE_APP_SOCKET_ENDPOINT || "http://localhost:3000");
+  let fallback = `${document.location.protocol}//${document.location.hostname}`;
+  if (document.location.hostname === "localhost")
+    fallback = `${fallback}:3000`;
+  const socket: Socket<ServerToClientEvents, ClientToServerEvents> = io(process.env.VUE_APP_SOCKET_ENDPOINT || fallback);
   return {
     socket
   };


### PR DESCRIPTION
closes #26 by improving the detection of the socketio host.
The steps are:
* use `export VUE_APP_SOCKET_ENDPOINT=https://my-custom-ws.com:4000` env variable if set - this needs to be set during build time of the docker container - useful if the websocket host deviates (e.g. different host or port)
* if `host == localhost` -> use `localhost:3000` as the vue development server (port 8080) has no websocket initaited which runs under `3000` in the dev setup
* otherwise use the base address of the website